### PR TITLE
chore: deprecate repo in favor of exploreomni/omni-agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
+> [!CAUTION]
+> **This repository is deprecated and no longer maintained.**
+> All skills, agents, and rules have been consolidated into [`exploreomni/omni-agent-skills`](https://github.com/exploreomni/omni-agent-skills), which supports Claude Code, Cursor, OpenAI Codex, Snowflake Cortex Code, GitHub Copilot, Gemini CLI, and other skills.sh-compatible agents.
+
+## Migrating
+
+Uninstall the old plugin and install the new one:
+
+```text
+# Remove the old plugin
+/remove-plugin omni-cursor-plugin
+
+# Install the new unified plugin
+/add-plugin https://github.com/exploreomni/omni-agent-skills.git
+```
+
+The new repo includes the same 8 skills, 3 subagents, and 3 `.mdc` rules, plus additional skills like `omni-ai-eval` and `omni-integrations`.
+
+---
+
+_The original README is preserved below for reference._
+
+---
+
 # Omni Analytics Plugin for Cursor
 
 A Cursor plugin that helps analytics engineers and data teams work with [Omni Analytics](https://omni.co) programmatically through Omni's REST APIs.


### PR DESCRIPTION
## Summary

- Adds a deprecation notice (GitHub `[!CAUTION]` admonition) to the top of `README.md` directing users to [`exploreomni/omni-agent-skills`](https://github.com/exploreomni/omni-agent-skills)
- Includes migration instructions for uninstalling the old plugin and installing the new unified one
- Preserves the original README content below for reference

All 8 skills, 3 subagents, and 3 `.mdc` rules from this repo have been consolidated into `omni-agent-skills`, which supports Claude Code, Cursor, OpenAI Codex, Snowflake Cortex Code, GitHub Copilot, Gemini CLI, and other skills.sh-compatible agents.

## Post-merge steps

- [ ] Archive the repository (Settings → Danger Zone → Archive this repository)
- [ ] Update the repo description to "⚠️ Deprecated — see exploreomni/omni-agent-skills"
- [ ] Add `deprecated` and `archived` topics to the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)